### PR TITLE
adding port to sameple_profile_expected as it was causing build to fa…

### DIFF
--- a/test_uperf_plugin.py
+++ b/test_uperf_plugin.py
@@ -45,7 +45,7 @@ sample_profile_expected = """<?xml version='1.0' encoding='us-ascii'?>
 <profile name="test">
   <group nthreads="1">
     <transaction iterations="1">
-      <flowop type="accept" options="remotehost=127.0.0.1 protocol=tcp tcp_nodelay wndsz=5k" />
+      <flowop type="accept" options="remotehost=127.0.0.1 port=20000 protocol=tcp tcp_nodelay wndsz=5k" />
     </transaction>
     <transaction duration="50ms">
       <flowop type="write" options="size=90k" />


### PR DESCRIPTION
…il in test

## Changes introduced with this PR

Adding `port=2000` to sample_profile_expected in `test_uperf_plugin.py` as I was getting a build failure when creating image. Adding this into expected allowed me to successfully build the image

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).