### PR TITLE
Switch to bytes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+doctests = True
+exclude = .venv,.git,.tox,dist,doc,build,__pycache__
+max-line-length = 88

--- a/.github/workflows/carpenter.yaml
+++ b/.github/workflows/carpenter.yaml
@@ -17,6 +17,7 @@ jobs:
   carpenter-build-prod:
     name: carpenter_build_prod
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout this project
@@ -28,6 +29,7 @@ jobs:
   carpenter-build-dev:
     name: carpenter_build_dev
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: github.ref != 'refs/heads/main'
     steps:
       - name: set_image_tag
@@ -43,4 +45,4 @@ jobs:
         uses: arcalot/arcaflow-plugin-image-builder@main
         with:
           args: build --build --push
-          
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,8 +53,8 @@ ENTRYPOINT ["python3.9", "uperf_plugin.py"]
 CMD []
 
 LABEL org.opencontainers.image.source="https://github.com/arcalot/arcaflow-plugin-uperf"
-LABEL org.opencontainers.image.licenses="Apache-2.0+GPL-3.0-only"
+LABEL org.opencontainers.image.licenses="Apache-2.0+GPL-2.0-only"
 LABEL org.opencontainers.image.vendor="Arcalot project"
 LABEL org.opencontainers.image.authors="Arcalot contributors"
-LABEL org.opencontainers.image.title="Uperf Arcalot Plugin"
+LABEL org.opencontainers.image.title="Python Plugin Template"
 LABEL io.github.arcalot.arcaflow.plugin.version="1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,8 +53,8 @@ ENTRYPOINT ["python3.9", "uperf_plugin.py"]
 CMD []
 
 LABEL org.opencontainers.image.source="https://github.com/arcalot/arcaflow-plugin-uperf"
-LABEL org.opencontainers.image.licenses="Apache-2.0+GPL-2.0-only"
+LABEL org.opencontainers.image.licenses="Apache-2.0+GPL-3.0-only"
 LABEL org.opencontainers.image.vendor="Arcalot project"
 LABEL org.opencontainers.image.authors="Arcalot contributors"
-LABEL org.opencontainers.image.title="Python Plugin Template"
+LABEL org.opencontainers.image.title="Uperf Arcalot Plugin"
 LABEL io.github.arcalot.arcaflow.plugin.version="1"

--- a/input/netperf.yaml
+++ b/input/netperf.yaml
@@ -9,7 +9,7 @@ groups:
           - type: "accept"
             remotehost: "server"
             protocol: "tcp"
-            wndsz: 50
+            wndsz: 5120
             tcp_nodelay: true
       - duration: "10s"
         flowops:

--- a/test_uperf_plugin.py
+++ b/test_uperf_plugin.py
@@ -20,7 +20,7 @@ simple_profile = uperf_schema.Profile(
                             type="accept",
                             remotehost="127.0.0.1",
                             protocol=uperf_schema.IProtocol.TCP,
-                            wndsz=5,
+                            wndsz=5120,
                             tcp_nodelay=True,
                         )
                     ],
@@ -45,11 +45,11 @@ sample_profile_expected = """<?xml version='1.0' encoding='us-ascii'?>
 <profile name="test">
   <group nthreads="1">
     <transaction iterations="1">
-      <flowop type="accept" options="remotehost=127.0.0.1 port=20000 protocol=tcp tcp_nodelay wndsz=5k" />
+      <flowop type="accept" options="remotehost=127.0.0.1 port=20000 protocol=tcp tcp_nodelay wndsz=5120b" />
     </transaction>
     <transaction duration="50ms">
-      <flowop type="write" options="size=90k" />
-      <flowop type="read" options="size=90k" />
+      <flowop type="write" options="size=90b" />
+      <flowop type="read" options="size=90b" />
     </transaction>
     <transaction iterations="1">
       <flowop type="disconnect" />

--- a/uperf_plugin.py
+++ b/uperf_plugin.py
@@ -15,7 +15,7 @@ from uperf_schema import (
     UPerfServerResults,
     UPerfServerParams,
     UPerfRawData,
-    Profile
+    Profile,
 )
 
 # Constants
@@ -36,9 +36,7 @@ def write_profile(profile: Profile):
         for transaction in group.transactions:
             transaction_element = ET.Element("transaction")
             if transaction.iterations is not None:
-                transaction_element.set(
-                    "iterations", str(transaction.iterations)
-                )
+                transaction_element.set("iterations", str(transaction.iterations))
             elif transaction.duration is not None:
                 transaction_element.set("duration", str(transaction.duration))
             elif transaction.rate is not None:
@@ -58,9 +56,7 @@ def write_profile(profile: Profile):
 
     # This project requires indented/formatted XML.
     ET.indent(tree)
-    ET.ElementTree(tree).write(
-        profile_path, encoding="us-ascii", xml_declaration=True
-    )
+    ET.ElementTree(tree).write(profile_path, encoding="us-ascii", xml_declaration=True)
     # It requires a newline at end of file
     with open(profile_path, "a") as profile_xml_file:
         profile_xml_file.write("\n")
@@ -88,9 +84,7 @@ def process_output(
     output: bytes,
 ) -> typing.Tuple[str, typing.Union[UPerfResults, UPerfError]]:
     decoded_output = output.decode("utf-8")
-    profile_run_search = re.search(
-        r"running profile:(.+) \.\.\.", decoded_output
-    )
+    profile_run_search = re.search(r"running profile:(.+) \.\.\.", decoded_output)
     if profile_run_search is None:
         return "error", UPerfError(
             "Failed to parse output: could not find profile name.\nOutput: "
@@ -120,11 +114,7 @@ def process_output(
         if ops != 0 or (transaction_index in transaction_last_timestamp):
             # Keep non-first zero values, but set ns_per_op to 0
             ns_per_op = (
-                int(
-                    1000
-                    * (time - transaction_last_timestamp[transaction_index])
-                    / ops
-                )
+                int(1000 * (time - transaction_last_timestamp[transaction_index]) / ops)
                 if ops != 0
                 else 0
             )
@@ -140,9 +130,7 @@ def process_output(
         transaction_last_timestamp[transaction_index] = time
 
     if len(timeseries_data_search) == 0:
-        return "error", UPerfError(
-            "No results found.\nOutput: " + decoded_output
-        )
+        return "error", UPerfError("No results found.\nOutput: " + decoded_output)
 
     return "success", UPerfResults(
         profile_name=profile_run, timeseries_data=timeseries_data


### PR DESCRIPTION
Fixes #20 

## Changes introduced with this PR
This PR allows you to set the size fields as bytes instead of only units of KiB.
It also uses the new unit feature of the SDK, which will make it so future GUIs can help the user pick sizes that are units of kib, mb, etc.

I also updated formatting with the `black` formatter, and validated with flake8, and I added a flake8 config file.

This PR is based on the housekeeping PR's branch, so it's recommended that you review that first, and only review the latest commit on this PR.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).